### PR TITLE
fix: ブレークポイント、モバイルメニュー表示の改修

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,23 +8,23 @@
 </head>
 <body>
   <header class="w-full font-handwriting">
-    <div class="flex flex-row items-center h-14 px-4 justify-between lg:justify-start">
+    <div class="flex flex-row items-center h-14 px-4 justify-between sm:justify-start">
         <!-- ロゴ -->
         <a class="text-xl" href="./index.html">Cafe Recursion</a>
 
-        <!-- デスクトップメニュー（lg以上で表示） -->
-        <div class="hidden lg:block">
+        <!-- デスクトップメニュー（sm以上で表示） -->
+        <div class="hidden sm:block">
           <div class="ml-4 flex flex-row items-baseline space-x-2">
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./index.html">Home</a>
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./drink.html">Drink</a>
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./sweets.html">Sweets</a>
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./food.html">Food</a>
-              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./information.html">Information</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./shop.html">Information</a>
           </div>
         </div>
 
-        <!-- モバイルトグルボタン（lg未満で表示） -->
-        <button id="mobile-menu-toggle" class="lg:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer" type="button"  aria-label="Toggle navigation menu" aria-expanded="false">
+        <!-- モバイルトグルボタン（sm未満で表示） -->
+        <button id="mobile-menu-toggle" class="sm:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer" type="button"  aria-label="Toggle navigation menu" aria-expanded="false">
           <!-- ハンバーガーアイコン -->
           <svg id="hamburger-icon" class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -37,13 +37,13 @@
     </div>
 
     <!-- モバイルメニュー（トグルで表示/非表示） -->
-    <div id="mobile-menu" class="lg:hidden hidden absolute bg-gray-200 w-full">
+    <div id="mobile-menu" class="sm:hidden hidden absolute bg-gray-200 w-full z-1">
         <div class="px-2 pt-2 pb-3 space-y-1 border-t border-gray-200">
           <a href="./index.html" class="block px-3 py-2 rounded-md text-base font-medium">Home</a>
           <a href="./drink.html" class="block px-3 py-2 rounded-md text-base font-medium">Drink</a>
           <a href="./sweets.html" class="block px-3 py-2 rounded-md text-base font-medium">Sweets</a>
           <a href="./food.html" class="block px-3 py-2 rounded-md text-base font-medium">Food</a>
-          <a href="./information.html" class="block px-3 py-2 rounded-md text-base font-medium">Information</a>
+          <a href="./shop.html" class="block px-3 py-2 rounded-md text-base font-medium">Information</a>
         </div>
     </div>
   </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./drink.html">Drink</a>
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./sweets.html">Sweets</a>
               <a class="px-3 py-2 rounded-md text-sm font-medium" href="./food.html">Food</a>
-              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./shop.html">Information</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./shop.html">Shop</a>
           </div>
         </div>
 
@@ -43,7 +43,7 @@
           <a href="./drink.html" class="block px-3 py-2 rounded-md text-base font-medium">Drink</a>
           <a href="./sweets.html" class="block px-3 py-2 rounded-md text-base font-medium">Sweets</a>
           <a href="./food.html" class="block px-3 py-2 rounded-md text-base font-medium">Food</a>
-          <a href="./shop.html" class="block px-3 py-2 rounded-md text-base font-medium">Information</a>
+          <a href="./shop.html" class="block px-3 py-2 rounded-md text-base font-medium">Shop</a>
         </div>
     </div>
   </header>

--- a/docs/output.css
+++ b/docs/output.css
@@ -184,6 +184,9 @@
   .relative {
     position: relative;
   }
+  .z-1 {
+    z-index: 1;
+  }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
@@ -201,9 +204,6 @@
   }
   .inline-flex {
     display: inline-flex;
-  }
-  .table {
-    display: table;
   }
   .h-6 {
     height: calc(var(--spacing) * 6);
@@ -223,14 +223,8 @@
   .h-screen {
     height: 100vh;
   }
-  .w-1 {
-    width: calc(var(--spacing) * 1);
-  }
   .w-1\/2 {
     width: calc(1/2 * 100%);
-  }
-  .w-1\/3 {
-    width: calc(1/3 * 100%);
   }
   .w-1\/4 {
     width: calc(1/4 * 100%);
@@ -255,12 +249,6 @@
   }
   .flex-1 {
     flex: 1;
-  }
-  .border-collapse {
-    border-collapse: collapse;
-  }
-  .transform {
-    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .animate-slide {
     animation: var(--animate-slide);
@@ -315,10 +303,6 @@
   }
   .rounded-md {
     border-radius: var(--radius-md);
-  }
-  .border {
-    border-style: var(--tw-border-style);
-    border-width: 1px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -390,16 +374,6 @@
   .text-gray-600 {
     color: var(--color-gray-600);
   }
-  .text-gray-700 {
-    color: var(--color-gray-700);
-  }
-  .underline {
-    text-decoration-line: underline;
-  }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
-  }
   .hover\:bg-gray-200 {
     &:hover {
       @media (hover: hover) {
@@ -431,6 +405,16 @@
       outline-style: none;
     }
   }
+  .sm\:block {
+    @media (width >= 40rem) {
+      display: block;
+    }
+  }
+  .sm\:hidden {
+    @media (width >= 40rem) {
+      display: none;
+    }
+  }
   .sm\:h-\[350px\] {
     @media (width >= 40rem) {
       height: 350px;
@@ -446,41 +430,11 @@
       width: 100%;
     }
   }
-  .lg\:block {
-    @media (width >= 64rem) {
-      display: block;
-    }
-  }
-  .lg\:hidden {
-    @media (width >= 64rem) {
-      display: none;
-    }
-  }
-  .lg\:justify-start {
-    @media (width >= 64rem) {
+  .sm\:justify-start {
+    @media (width >= 40rem) {
       justify-content: flex-start;
     }
   }
-}
-@property --tw-rotate-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-y {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-z {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-y {
-  syntax: "*";
-  inherits: false;
 }
 @property --tw-space-y-reverse {
   syntax: "*";
@@ -500,11 +454,6 @@
 @property --tw-font-weight {
   syntax: "*";
   inherits: false;
-}
-@property --tw-outline-style {
-  syntax: "*";
-  inherits: false;
-  initial-value: solid;
 }
 @property --tw-shadow {
   syntax: "*";
@@ -603,16 +552,10 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
-      --tw-rotate-x: initial;
-      --tw-rotate-y: initial;
-      --tw-rotate-z: initial;
-      --tw-skew-x: initial;
-      --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
       --tw-border-style: solid;
       --tw-font-weight: initial;
-      --tw-outline-style: solid;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;


### PR DESCRIPTION
<!-- for GitHub Copilot review rule: I want to review in Japanese. -->
# Issue
- #26 

# やったこと
ブレークポイントの改修
モバイルメニュー表示の改修
shop informationページのリンク修正

# 確認事項
画面の表示幅が639px以下になったときにトグルボタンが表示されること
モバイル表示でトグルボタンを押下するとメニューが表示されること
informationを押下するとページ遷移すること