### PR TITLE
feat: Shopページにもトップページと同じヘッダーを実装

### DIFF
--- a/docs/shop.html
+++ b/docs/shop.html
@@ -6,11 +6,51 @@
   <link href="https://fonts.googleapis.com/css2?family=Nothing+You+Could+Do&display=swap" rel="stylesheet">
   <title>Shop - Cafe Recursion</title>
   <link href="./output.css" rel="stylesheet">
+  <script src="./js/header.js" defer></script>
 </head>
 <body class="h-screen flex flex-col relative">
-  <header>
-    ヘッダー
+  <header class="w-full font-handwriting">
+    <div class="flex flex-row items-center h-14 px-4 justify-between sm:justify-start">
+        <!-- ロゴ -->
+        <a class="text-xl" href="./index.html">Cafe Recursion</a>
+
+        <!-- デスクトップメニュー（sm以上で表示） -->
+        <div class="hidden sm:block">
+          <div class="ml-4 flex flex-row items-baseline space-x-2">
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./index.html">Home</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./drink.html">Drink</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./sweets.html">Sweets</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./food.html">Food</a>
+              <a class="px-3 py-2 rounded-md text-sm font-medium" href="./shop.html">Shop</a>
+          </div>
+        </div>
+
+        <!-- モバイルトグルボタン（sm未満で表示） -->
+        <button id="mobile-menu-toggle" class="sm:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer" type="button"  aria-label="Toggle navigation menu" aria-expanded="false">
+          <!-- ハンバーガーアイコン -->
+          <svg id="hamburger-icon" class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <!-- クローズアイコン -->
+          <svg id="close-icon" class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+    </div>
+
+    <!-- モバイルメニュー（トグルで表示/非表示） -->
+    <div id="mobile-menu" class="sm:hidden hidden absolute bg-gray-200 w-full z-1">
+        <div class="px-2 pt-2 pb-3 space-y-1 border-t border-gray-200">
+          <a href="./index.html" class="block px-3 py-2 rounded-md text-base font-medium">Home</a>
+          <a href="./drink.html" class="block px-3 py-2 rounded-md text-base font-medium">Drink</a>
+          <a href="./sweets.html" class="block px-3 py-2 rounded-md text-base font-medium">Sweets</a>
+          <a href="./food.html" class="block px-3 py-2 rounded-md text-base font-medium">Food</a>
+          <a href="./shop.html" class="block px-3 py-2 rounded-md text-base font-medium">Shop</a>
+        </div>
+    </div>
   </header>
+
+  <!-- メインコンテンツ -->
   <main class="flex flex-1 w-full justify-center">
     <div class="flex flex-col items-center sm:w-3/4 w-full h-full space-y-2">
       <div class="flex flex-col items-center font-handwriting py-5 space-y-2">

--- a/docs/shop.html
+++ b/docs/shop.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="https://fonts.googleapis.com/css2?family=Nothing+You+Could+Do&display=swap" rel="stylesheet">
   <title>Shop - Cafe Recursion</title>
   <link href="./output.css" rel="stylesheet">
   <script src="./js/header.js" defer></script>


### PR DESCRIPTION
<!-- for GitHub Copilot review rule: I want to review in Japanese. -->
# Issue
- #32

# やったこと
- [feat: Shopページにもトップページと同じヘッダーを実装](https://github.com/teamdev-beginner-202506-a4/work-space/pull/34/commits/720147af7f366bf157192cf548a9ee40de1539c0)
- [refactor: Shopページで直接インポートしていた、Nothing You Could Doフォントのlinkを削除する](https://github.com/teamdev-beginner-202506-a4/work-space/pull/34/commits/b3873a694bc42153c845f7ae1b49c9500b278860)

# 確認事項
- PC画面
  
![スクリーンショット 2025-07-06 1 49 19](https://github.com/user-attachments/assets/8b15ae5c-db6b-4e5f-83a1-06a34f6046a9)

- モバイル画面
![スクリーンショット 2025-07-06 1 49 42](https://github.com/user-attachments/assets/d178cccd-9197-4ff6-89a2-9b4b32f11be6)
